### PR TITLE
Write compilation stderr to document

### DIFF
--- a/lib/elm_sprockets/elm_processor.rb
+++ b/lib/elm_sprockets/elm_processor.rb
@@ -28,13 +28,38 @@ module ElmSprockets
       data = input[:data]
       context = input[:environment].context_class.new(input)
       elm = input[:cache].fetch(@cache_key + [input[:filename]] + [data]) do
-        Autoload::Elm.compiler.content(input[:data]).to_s
+        either do
+          Autoload::Elm.compiler.content(input[:data]).to_s
+        end
       end
       deps = Elm::Dependencies.from_content(data)
       deps.each do |dep|
         context.depend_on File.absolute_path(dep)
       end
-      context.metadata.merge(data: elm.output)
+      if elm[:right]
+        context.metadata.merge(data: elm[:right].output)
+      else
+        context.metadata.merge(data: error_message(elm[:left]))
+      end
+    end
+
+    def error_message(raw)
+      raw.message.each_line.map do |line|
+        line.gsub(/"/, '\"').sub(/^$/,'&nbsp;').rstrip
+      end.map do |cleaned|
+        %Q|document.write("<pre><code>#{cleaned}</code></pre>");|
+      end.join("\n")
+    end
+
+    def either(&block)
+      ret = nil
+      begin
+        ret = block.call
+      rescue Exception => e
+        {left: e}
+      else
+        {right: ret}
+      end
     end
   end
 end


### PR DESCRIPTION
If compilation succeeds, this PR effectively does nothing. If compilation fails, this PR will generate a bunch of `document.write(...)` statements containing Elm's error.

It's not color-coded, and the filename is wrong, but it's way better than diving into the JS console to read the error message.